### PR TITLE
[Fix] Change widget name in tutorial from 'test' to 'RandomNumber'

### DIFF
--- a/src/doc/tutorials/en/001-beginning.tid
+++ b/src/doc/tutorials/en/001-beginning.tid
@@ -59,10 +59,10 @@ npm run dev
 
 If no errors are reported, the console will show a local URL (usually `http://127.0.0.1:8080`), and if you browse this URL with your browser, you will see a Wiki page, which will also show this tutorial first. Further inspection shows that this Wiki has the plugin `$:/plugins/your-name/plugin-name` installed.
 
-This sample plugin implements a widget called `test` that displays a fixed line of text. We create a tiddler called Test in which we use this widget.
+This sample plugin implements a widget called `RandomNumber` that displays a fixed line of text. We create a tiddler called Test in which we use this widget.
 
 ```
-<$test />
+<$RandomNumber />
 ```
 
 Save to see the words `This is a widget!`.

--- a/src/doc/tutorials/zh/001-beginning.tid
+++ b/src/doc/tutorials/zh/001-beginning.tid
@@ -64,10 +64,10 @@ npm run dev
 
 如果没有报错，则控制台会显示出一个本地网址(一般是 `http://127.0.0.1:8080`)，使用浏览器浏览此网址，可以看到一个 Wiki 页面，页面首先也会显示本教程。进一步查看可发现，这个 Wiki 安装了插件 `$:/plugins/your-name/plugin-name`。
 
-这个示例插件实现了一个叫 test 的微件，作用是显示一行固定的文字。我们创建一个称为 Test 的 tiddler，在其中使用这个微件：
+这个示例插件实现了一个叫 RandomNumber 的微件，作用是显示一行固定的文字。我们创建一个称为 Test 的 tiddler，在其中使用这个微件：
 
 ```
-<$test />
+<$RandomNumber />
 ```
 
 保存可看到 `This is a widget!` 的字样。


### PR DESCRIPTION
* Updated the widget name from 'test' to 'RandomNumber' in the tutorial.
* The 'test' widget actually is not exist in **index.ts**, it was called `RandomNumber`.